### PR TITLE
removing deprecated field

### DIFF
--- a/lib/shopify/resources/shipping_line.ex
+++ b/lib/shopify/resources/shipping_line.ex
@@ -11,7 +11,6 @@ defmodule Shopify.ShippingLine do
     :tax_lines,
     :carrier_identifier,
     :requested_fulfillment_service_id,
-    :delivery_category,
     :id,
     :phone
   ]

--- a/test/fixtures/checkouts.json
+++ b/test/fixtures/checkouts.json
@@ -22,7 +22,6 @@
                     "source": "shopify",
                     "title": "Standard Shipping",
                     "phone": null,
-                    "delivery_category": null,
                     "carrier_identifier": null,
                     "carrier_service_id": null,
                     "api_client_id": null,

--- a/test/fixtures/customers/1/orders.json
+++ b/test/fixtures/customers/1/orders.json
@@ -187,7 +187,6 @@
           "source": "shopify",
           "phone": null,
           "requested_fulfillment_service_id": null,
-          "delivery_category": null,
           "carrier_identifier": null,
           "discounted_price": "0.00",
           "tax_lines": []

--- a/test/fixtures/orders/1.json
+++ b/test/fixtures/orders/1.json
@@ -185,7 +185,6 @@
         "source": "shopify",
         "phone": null,
         "requested_fulfillment_service_id": null,
-        "delivery_category": null,
         "carrier_identifier": null,
         "tax_lines": [
         ]


### PR DESCRIPTION
https://shopify.dev/changelog/removal-of-the-delivery_category-field-on-order-shipping-lines